### PR TITLE
supports overwriting model output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ generator nestjsDto {
 All parameters are optional.
 
 - [`output`]: (default: `"../src/generated/nestjs-dto"`) - output path relative to your `schema.prisma` file
-- [`outputToNestJsResourceStructure`]: (default: `"false"`) - writes `dto`s and `entities` to subfolders aligned with [NestJS CRUD generator](https://docs.nestjs.com/recipes/crud-generator). Resource module name is derived from lower-cased model name in `schema.prisma`
+- [`outputToNestJsResourceStructure`]: (default: `"false"`) - writes `dto`s and `entities` to subfolders aligned with [NestJS CRUD generator](https://docs.nestjs.com/recipes/crud-generator). Resource module name is derived from lower-cased model name in `schema.prisma`, or will be overwritten by `@DtoFolder`
 - [`exportRelationModifierClasses`]: (default: `"true"`) - Should extra classes generated for relationship field operations on DTOs be exported?
 - [`reExport`]: (default: `false`) - Should an index.ts be created for every folder?
 - [`createDtoPrefix`]: (default: `"Create"`) - phrase to prefix every `CreateDTO` class with
@@ -66,6 +66,7 @@ model Post {
 ```
 
 - @DtoReadOnly - omits field in `CreateDTO` and `UpdateDTO`
+- @DtoFolder *`<folder>`* - set specific output folder for targeted model - useful when you have module directories with names in plural form
 - @DtoEntityHidden - omits field in `Entity`
 - @DtoCreateOptional - adds field **optionally** to `CreateDTO` - useful for fields that would otherwise be omitted (e.g. `@id`, `@updatedAt`)
 - @DtoUpdateOptional- adds field **optionally** to `UpdateDTO` - useful for fields that would otherwise be omitted (e.g. `@id`, `@updatedAt`)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ datasource db {
 generator nestjsDto {
   provider                        = "node -r ts-node/register/transpile-only src/cli.ts"
   output                          = "../src/@generated/prisma-generator-nestjs-dto"
-  outputToNestJsResourceStructure = "false"
+  outputToNestJsResourceStructure = "true"
   exportRelationModifierClasses   = "true"
   reExport                        = "true"
   createDtoPrefix                 = "Create"
@@ -17,6 +17,7 @@ generator nestjsDto {
   fileNamingStyle                 = "camel"
 }
 
+/// @DtoFolder products
 model Product {
   id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name        String   @db.VarChar(255)

--- a/src/generator/annotations.ts
+++ b/src/generator/annotations.ts
@@ -26,3 +26,7 @@ export const DTO_RELATION_MODIFIERS_ON_UPDATE = [
   DTO_RELATION_CAN_CRAEATE_ON_UPDATE,
   DTO_RELATION_CAN_CONNECT_ON_UPDATE,
 ];
+export const DTO_FOLDER = /@DtoFolder (?<folder>\w+)/;
+export const DTO_VARIABLES = {
+  folder: DTO_FOLDER,
+};

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -7,11 +7,12 @@ import { generateConnectDto } from './generate-connect-dto';
 import { generateCreateDto } from './generate-create-dto';
 import { generateUpdateDto } from './generate-update-dto';
 import { generateEntity } from './generate-entity';
-import { DTO_IGNORE_MODEL } from './annotations';
+import { DTO_FOLDER, DTO_IGNORE_MODEL } from './annotations';
 import { isAnnotatedWith } from './field-classifiers';
 
 import type { DMMF } from '@prisma/generator-helper';
 import { NamingStyle, Model, WriteableFileSpecs } from './types';
+import { getOutputFolder } from './model-classifiers';
 
 interface RunParam {
   output: string;
@@ -63,13 +64,25 @@ export const run = ({
       ...model,
       output: {
         dto: outputToNestJsResourceStructure
-          ? path.join(output, transformFileNameCase(model.name), 'dto')
+          ? path.join(
+              output,
+              getOutputFolder(model) || transformFileNameCase(model.name),
+              'dto',
+            )
           : output,
         entity: outputToNestJsResourceStructure
-          ? path.join(output, transformFileNameCase(model.name), 'entities')
+          ? path.join(
+              output,
+              getOutputFolder(model) || transformFileNameCase(model.name),
+              'entities',
+            )
           : output,
       },
     }));
+
+  filteredModels.map((model) =>
+    console.log(isAnnotatedWith(model, DTO_FOLDER)),
+  );
 
   const modelFiles = filteredModels.map((model) => {
     logger.info(`Processing Model ${model.name}`);

--- a/src/generator/model-classifiers.ts
+++ b/src/generator/model-classifiers.ts
@@ -1,0 +1,14 @@
+import { DTO_VARIABLES } from './annotations';
+import type { DMMF } from '@prisma/generator-helper';
+
+export const isAnnotatedWithVariable = (
+  instance: DMMF.Field | DMMF.Model,
+  variableName: keyof typeof DTO_VARIABLES,
+): string | undefined => {
+  const { documentation = '' } = instance;
+  const match = documentation.match(DTO_VARIABLES[variableName]);
+  return match?.groups?.[variableName];
+};
+
+export const getOutputFolder = (model: DMMF.Model): string | undefined =>
+  isAnnotatedWithVariable(model, 'folder');


### PR DESCRIPTION
Since API endpoints & module names are often in plural form, NestJS also follow that convention; I came up with this solution to overwrite the output folder for some particular models.

`@DtoFolder <folder>`

**TODO**: Regex for valid folder name needs some improvements.