### PR TITLE
Add option enumAsSchema for enumName support, @ApiProperty decorators for entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ generator nestjsDto {
   entityPrefix                    = ""
   entitySuffix                    = ""
   fileNamingStyle                 = "camel"
+  enumAsSchema                    = "false"
 }
 ```
 
@@ -52,6 +53,7 @@ All parameters are optional.
 - [`entityPrefix`]: (default: `""`) - phrase to prefix every `Entity` class with
 - [`entitySuffix`]: (default: `""`) - phrase to suffix every `Entity` class with
 - [`fileNamingStyle`]: (default: `"camel"`) - how to name generated files. Valid choices are `"camel"`, `"pascal"`, `"kebab"` and `"snake"`.
+- [`enumAsSchema`]: (default: `"false"`) - Should enum values be reusable schemas? if `"true"`, `enumName` will be attached to `@ApiProperty` options. 
 
 ## <a name="annotations"></a>Annotations
 

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -29,6 +29,7 @@ export const computeEntityParams = ({
   allModels,
   templateHelpers,
 }: ComputeEntityParamsParam): EntityParams => {
+  let hasEnum = false;
   const imports: ImportStatementParams[] = [];
   const apiExtraModels: string[] = [];
 
@@ -110,11 +111,17 @@ export const computeEntityParams = ({
       overrides.isNullable = !isAnyRelationRequired;
     }
 
+    if (field.kind === 'enum') hasEnum = true;
+
     return [...result, mapDMMFToParsedField(field, overrides)];
   }, [] as ParsedField[]);
 
-  if (apiExtraModels.length)
-    imports.unshift({ from: '@nestjs/swagger', destruct: ['ApiExtraModels'] });
+  if (apiExtraModels.length || hasEnum) {
+    const destruct = [];
+    if (apiExtraModels.length) destruct.push('ApiExtraModels');
+    if (hasEnum) destruct.push('ApiProperty');
+    imports.unshift({ from: '@nestjs/swagger', destruct });
+  }
 
   const importPrismaClient = makeImportsFromPrismaClient(fields);
   if (importPrismaClient) imports.unshift(importPrismaClient);

--- a/src/generator/generate-connect-dto.ts
+++ b/src/generator/generate-connect-dto.ts
@@ -2,16 +2,18 @@ import type { TemplateHelpers } from './template-helpers';
 import type { ConnectDtoParams } from './types';
 
 interface GenerateConnectDtoParam extends ConnectDtoParams {
+  enumAsSchema: boolean;
   templateHelpers: TemplateHelpers;
 }
 export const generateConnectDto = ({
   model,
   fields,
+  enumAsSchema,
   templateHelpers: t,
 }: GenerateConnectDtoParam) => {
   const template = `
   export class ${t.connectDtoName(model.name)} {
-    ${t.fieldsToDtoProps(fields, true)}
+    ${t.fieldsToDtoProps(fields, enumAsSchema, true)}
   }
   `;
 

--- a/src/generator/generate-create-dto.ts
+++ b/src/generator/generate-create-dto.ts
@@ -3,6 +3,7 @@ import type { CreateDtoParams } from './types';
 
 interface GenerateCreateDtoParam extends CreateDtoParams {
   exportRelationModifierClasses: boolean;
+  enumAsSchema: boolean;
   templateHelpers: TemplateHelpers;
 }
 export const generateCreateDto = ({
@@ -12,6 +13,7 @@ export const generateCreateDto = ({
   extraClasses,
   apiExtraModels,
   exportRelationModifierClasses,
+  enumAsSchema,
   templateHelpers: t,
 }: GenerateCreateDtoParam) => `
 ${t.importStatements(imports)}
@@ -24,6 +26,6 @@ ${t.each(
 
 ${t.if(apiExtraModels.length, t.apiExtraModels(apiExtraModels))}
 export class ${t.createDtoName(model.name)} {
-  ${t.fieldsToDtoProps(fields, true)}
+  ${t.fieldsToDtoProps(fields, enumAsSchema, true)}
 }
 `;

--- a/src/generator/generate-entity.ts
+++ b/src/generator/generate-entity.ts
@@ -2,6 +2,7 @@ import type { TemplateHelpers } from './template-helpers';
 import type { EntityParams } from './types';
 
 interface GenerateEntityParam extends EntityParams {
+  enumAsSchema: boolean;
   templateHelpers: TemplateHelpers;
 }
 export const generateEntity = ({
@@ -9,12 +10,13 @@ export const generateEntity = ({
   fields,
   imports,
   apiExtraModels,
+  enumAsSchema,
   templateHelpers: t,
 }: GenerateEntityParam) => `
 ${t.importStatements(imports)}
 
 ${t.if(apiExtraModels.length, t.apiExtraModels(apiExtraModels))}
 export class ${t.entityName(model.name)} {
-  ${t.fieldsToEntityProps(fields)}
+  ${t.fieldsToEntityProps(fields, enumAsSchema)}
 }
 `;

--- a/src/generator/generate-update-dto.ts
+++ b/src/generator/generate-update-dto.ts
@@ -3,6 +3,7 @@ import type { UpdateDtoParams } from './types';
 
 interface GenerateUpdateDtoParam extends UpdateDtoParams {
   exportRelationModifierClasses: boolean;
+  enumAsSchema: boolean;
   templateHelpers: TemplateHelpers;
 }
 export const generateUpdateDto = ({
@@ -12,6 +13,7 @@ export const generateUpdateDto = ({
   extraClasses,
   apiExtraModels,
   exportRelationModifierClasses,
+  enumAsSchema,
   templateHelpers: t,
 }: GenerateUpdateDtoParam) => `
 ${t.importStatements(imports)}
@@ -24,6 +26,6 @@ ${t.each(
 
 ${t.if(apiExtraModels.length, t.apiExtraModels(apiExtraModels))}
 export class ${t.updateDtoName(model.name)} {
-  ${t.fieldsToDtoProps(fields, true)}
+  ${t.fieldsToDtoProps(fields, enumAsSchema, true)}
 }
 `;

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -25,6 +25,7 @@ interface RunParam {
   entityPrefix: string;
   entitySuffix: string;
   fileNamingStyle: NamingStyle;
+  enumAsSchema: boolean;
 }
 
 export const run = ({
@@ -36,6 +37,7 @@ export const run = ({
     exportRelationModifierClasses,
     outputToNestJsResourceStructure,
     fileNamingStyle = 'camel',
+    enumAsSchema,
     ...preAndSuffixes
   } = options;
 
@@ -89,6 +91,7 @@ export const run = ({
       content: generateConnectDto({
         ...modelParams.connect,
         templateHelpers,
+        enumAsSchema,
       }),
     };
 
@@ -102,6 +105,7 @@ export const run = ({
         ...modelParams.create,
         exportRelationModifierClasses,
         templateHelpers,
+        enumAsSchema,
       }),
     };
     // TODO generate create-model.struct.ts
@@ -116,6 +120,7 @@ export const run = ({
         ...modelParams.update,
         exportRelationModifierClasses,
         templateHelpers,
+        enumAsSchema,
       }),
     };
     // TODO generate update-model.struct.ts
@@ -129,6 +134,7 @@ export const run = ({
       content: generateEntity({
         ...modelParams.entity,
         templateHelpers,
+        enumAsSchema,
       }),
     };
     // TODO generate model.struct.ts

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -167,7 +167,10 @@ export const makeHelpers = ({
     )}`;
 
   const fieldToEntityProp = (field: ParsedField) =>
-    `${field.name}${unless(field.isRequired, '?')}: ${fieldType(field)} ${when(
+    `${when(
+      field.kind === 'enum',
+      `@ApiProperty({ enum: ${fieldType(field, false)}})\n`,
+    )}${field.name}${unless(field.isRequired, '?')}: ${fieldType(field)} ${when(
       field.isNullable,
       ' | null',
     )};`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,12 @@ export const generate = (options: GeneratorOptions) => {
     false,
   );
 
+  const enumAsSchema = stringToBoolean(
+    options.generator.config.enumAsSchema,
+    // using `true` as default value would be a breaking change
+    false,
+  );
+
   const supportedFileNamingStyles = ['kebab', 'camel', 'pascal', 'snake'];
   const isSupportedFileNamingStyle = (style: string): style is NamingStyle =>
     supportedFileNamingStyles.includes(style);
@@ -75,6 +81,7 @@ export const generate = (options: GeneratorOptions) => {
     entityPrefix,
     entitySuffix,
     fileNamingStyle,
+    enumAsSchema,
   });
 
   const indexCollections: Record<string, WriteableFileSpecs> = {};


### PR DESCRIPTION
Hi. I love this generator that I can reduce chore jobs making classes for all entities which already inferable

1. I want to use the pure "Entity" class as response data, however, the enum properties do not appear in the scheme.  
Decorator `@ApiProperty` for Enum property in entities is also required so that swagger can show what enums would appear in certain entity responses. 
So this change appends decorator also for the entities not only for DTOs!  
[Before]
![image](https://user-images.githubusercontent.com/17665311/173803589-70634743-3828-441f-851a-160c62861963.png)
[After]
![image](https://user-images.githubusercontent.com/17665311/173803669-5ee6bc84-068d-45e3-ae9f-f4b7147aa21a.png)

2. since `nestjs/swagger` supports [reusable enum](https://github.com/nestjs/swagger/issues/372) so I added an option to attach [enumName](https://github.com/nestjs/swagger/pull/412) for enum properties called `enumAsSchema`. If set true(which is not default), enumName will be automatically attached to the `@ApiDecorator`s' option with it's field type